### PR TITLE
Add config test and npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "node --test",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/tests/drizzle.config.test.ts
+++ b/tests/drizzle.config.test.ts
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import config from '../drizzle.config.ts';
+
+assert.ok(config, 'Config should be defined');
+assert.equal(typeof config, 'object', 'Config should be an object');
+assert.ok(config.dbCredentials?.url, 'dbCredentials.url should be defined');


### PR DESCRIPTION
## Summary
- add basic unit test that checks `dbCredentials.url` exists
- provide npm script to run the test suite

## Testing
- `node --test tests/drizzle.config.test.ts` *(fails: Unknown file extension `.ts`)*
- `npm test` *(shows 0 tests due to above issue)*

------
https://chatgpt.com/codex/tasks/task_e_68517b4c7234832eb7a72d67e6356b44