### PR TITLE
Fix mismatch on tsx watch mode

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -100,7 +100,7 @@ This is a full-stack weight loss application built with TypeScript, React, Expre
 - **Runtime**: Node.js 20 via Replit
 - **Database**: PostgreSQL 16 provision
 - **Hot Reload**: Vite HMR for frontend changes
-- **Server Restart**: tsx watch mode for backend changes
+- **Server Restart**: tsx run for backend (manual restart)
 
 ### Production Build
 - **Frontend**: Vite production build to `dist/public`


### PR DESCRIPTION
## Summary
- note that the dev server uses `tsx` without watch mode

## Testing
- `npm run check` *(fails: No inputs found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517b4c5a08832e86b7ebf72479dab3