### PR TITLE
Add dotenv to drizzle config

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
 if (!process.env.DATABASE_URL) {


### PR DESCRIPTION
## Summary
- load environment variables automatically for `drizzle-kit`

## Testing
- `npm run check` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68517b4b96c8832e8c71c27533bf83db