### PR TITLE
Fix drizzle config error message

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "drizzle-kit";
 
 if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
+  throw new Error("DATABASE_URL is not set. Ensure the database is provisioned.");
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- clarify the error text thrown when `DATABASE_URL` is missing

## Testing
- `npm run check` *(fails: TS18003 - no inputs were found in config)*

------
https://chatgpt.com/codex/tasks/task_e_68517b4a881c832e98e6ff899e0e88e8