### PR TITLE
Fix dev script with missing server entry

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = Number(process.env.PORT) || 3000;
+
+app.get('/', (_req, res) => {
+  res.send('Server is running');
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Express server entry so `npm run dev` works

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68517f4c5d98832e88a2ea7ed28e53c1